### PR TITLE
fix(rollup): change rollup config for node and browser

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,23 @@
 {
   "presets": [
-    [
-      "env", { "modules": false }
-    ],
-    "react"
+    ["@babel/env", { "modules": false, "loose": true }],
+    "@babel/react"
   ],
   "plugins": [
-    "external-helpers"
-  ]
+    ["@babel/proposal-object-rest-spread", { "loose": true }],
+    ["@babel/proposal-class-properties", { "loose": true }]
+  ],
+  "env": {
+    "cjs": {
+      "plugins": [
+        "@babel/transform-runtime",
+        "@babel/transform-modules-commonjs"
+      ]
+    },
+    "esm": {
+      "plugins": [
+        "@babel/transform-runtime"
+      ]
+    }
+  }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,0 +1,26 @@
+{
+  "dist/laboratoria-ui.cjs.js": {
+    "bundled": 24170,
+    "minified": 22117,
+    "gzipped": 7415
+  },
+  "dist/laboratoria-ui.esm.js": {
+    "bundled": 23698,
+    "minified": 21757,
+    "gzipped": 7330,
+    "treeshaked": {
+      "rollup": {
+        "code": 20723,
+        "import_statements": 496
+      },
+      "webpack": {
+        "code": 22233
+      }
+    }
+  },
+  "dist/laboratoria-ui.umd.js": {
+    "bundled": 358158,
+    "minified": 148718,
+    "gzipped": 39229
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,18 +1,28 @@
 {
   "name": "laboratoria-ui",
   "version": "2.0.9",
-  "main": "dist/umd/laboratoria-ui.production.min.js",
+  "main": "dist/laboratoria-ui.cjs.js",
+  "module": "dist/laboratoria-ui.esm.js",
   "repository": "https://github.com/Laboratoria/ui.git",
   "author": "Laboratoria Devs Team",
   "license": "MIT",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "dist": "rollup -c rollup.config.js",
+    "dist": "rollup -c",
     "test": "./node_modules/.bin/eslint src/**/*.jsx && react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
     "@material-ui/core": "^1.4.2",
     "babel-core": "^6.26.3",
     "babel-plugin-external-helpers": "^6.22.0",
@@ -30,11 +40,14 @@
     "react-dom": "^16.4.2",
     "react-scripts": "1.1.4",
     "rollup": "^0.63.4",
-    "rollup-plugin-babel": "^3.0.7",
+    "rollup-plugin-babel": "^4.0.2",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-ignore": "^1.0.3",
     "rollup-plugin-jsx": "^1.0.3",
     "rollup-plugin-node-globals": "^1.2.1",
-    "rollup-plugin-node-resolve": "^3.3.0"
+    "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-size-snapshot": "^0.6.1",
+    "rollup-plugin-svg": "^1.0.1",
+    "rollup-plugin-uglify": "^5.0.2"
   }
 }

--- a/src/components/Buttons/PrimaryButton.jsx
+++ b/src/components/Buttons/PrimaryButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import withStyles from '@material-ui/core/styles/withStyles';
 import Button from '@material-ui/core/Button';
 
 const styles = theme => ({

--- a/src/components/Cards/CardMediaGitHub.jsx
+++ b/src/components/Cards/CardMediaGitHub.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import withStyles from '@material-ui/core/styles/withStyles';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';

--- a/src/components/Theme.jsx
+++ b/src/components/Theme.jsx
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
 
 const theme = createMuiTheme({
   palette: {

--- a/src/components/Typography/TypographyDisplay5.jsx
+++ b/src/components/Typography/TypographyDisplay5.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 const styles = theme => ({
   body1: theme.typography.display5,

--- a/src/components/Typography/TypographyDisplay6.jsx
+++ b/src/components/Typography/TypographyDisplay6.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 const styles = theme => ({
   body1: theme.typography.display6,

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -1,14 +1,5 @@
-import Theme from './Theme';
-import Buttons from './Buttons';
-import Header from './partials/Header';
-import { TypographyDisplay5, TypographyDisplay6 } from './Typography';
-import CardMediaGitHub from './Cards';
-
-export {
-  Theme,
-  TypographyDisplay5,
-  TypographyDisplay6,
-  Buttons,
-  Header,
-  CardMediaGitHub,
-};
+export { default as Theme } from './Theme';
+export { default as Buttons } from './Buttons';
+export { default as Header } from './partials/Header';
+export { TypographyDisplay5, TypographyDisplay6 } from './Typography';
+export { default as CardMediaGitHub } from './Cards';


### PR DESCRIPTION
* Change `rollup.config.js` to generate correctly  all bundles
* Bundles formats `cjs`, `esm`  and`umd`
* Change `.babelr`c to attend the new rollup.config.js config
* Setup  `rollup.config.j`s  to autogenerate `.size-snapshot.json`
* Change `destructuring` import to directly import
* Setup rollup to works with `SVG` files

_cjs – CommonJS, suitable for Node and Browserify/Webpack_
_esm – Keep the bundle as an ES module file_
_umd – Universal Module Definition, works as amd, cjs and iife all in one_