### PR TITLE
refactor(components): update CSS styles of Login and SignUp

### DIFF
--- a/src/components/Buttons/PrimaryButton.jsx
+++ b/src/components/Buttons/PrimaryButton.jsx
@@ -18,6 +18,9 @@ const styles = theme => ({
       backgroundColor: theme.palette.primary.light,
       cursor: 'pointer',
     },
+    [theme.breakpoints.only('xs')]: {
+      width: '100%',
+    },
   },
 });
 

--- a/src/components/Inputs/TextField.jsx
+++ b/src/components/Inputs/TextField.jsx
@@ -26,7 +26,7 @@ class TextField extends Component {
     const { label, classes, inputProps } = this.props;
     return (
       <FormControl className={classes.root}>
-        <InputLabel shrink htmlFor={inputProps.id}>
+        <InputLabel className={classes.label} shrink htmlFor={inputProps.id}>
           { label }
         </InputLabel>
         <Input

--- a/src/components/Inputs/style.js
+++ b/src/components/Inputs/style.js
@@ -1,7 +1,7 @@
 export default {
   root: {
-    boxSizing: 'border-box',
     borderRadius: 2,
+    boxSizing: 'border-box',
     display: 'flex',
     marginBottom: 20,
   },

--- a/src/components/Inputs/style.js
+++ b/src/components/Inputs/style.js
@@ -5,6 +5,12 @@ export default {
     display: 'flex',
     marginBottom: 20,
   },
+  label: {
+    color: '#000',
+    '& + [class*="MuiInput-formControl"]': {
+      marginTop: 20,
+    },
+  },
   input: {
     background: 'white',
     marginTop: 20,

--- a/src/components/Inputs/style.js
+++ b/src/components/Inputs/style.js
@@ -12,10 +12,9 @@ export default {
     },
   },
   input: {
-    background: 'white',
-    marginTop: 20,
-    padding: 17,
-    color: '#979797',
+    background: '#f7f7f7',
+    color: '#000',
     fontSize: 20,
+    padding: 16,
   },
 };

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 
 import PrimaryButton from '../Buttons';
 import Link from '../Links';
 import TextField from '../Inputs/TextField';
 
-const style = {
+const style = theme => ({
   root: {
     flexGrow: 1,
     '& a': {
       border: 'none',
+      [theme.breakpoints.only('xs')]: {
+        fontSize: 14,
+      },
     },
     '& strong': {
       fontWeight: 400,
@@ -20,11 +23,16 @@ const style = {
   },
   action: {
     width: '100%',
-    textAlign: 'center',
     marginTop: 20,
     marginBottom: 20,
   },
-};
+  textCenter: {
+    textAlign: 'center',
+  },
+  textRight: {
+    textAlign: 'right',
+  },
+});
 
 const Login = ({
   onSubmit, onBlur, labels, recoveryPass, createAccount, classes,
@@ -61,25 +69,15 @@ const Login = ({
         }}
       />
 
-      <Typography
-        component="p"
-        align="right"
-      >
-        { recoveryPass }
-      </Typography>
+      <div className={classes.textRight}>{recoveryPass}</div>
 
-      <div className={classes.action}>
+      <div className={classNames(classes.textCenter, classes.action)}>
         <PrimaryButton tag="button" type="submit">
           {labels.submit}
         </PrimaryButton>
       </div>
 
-      <Typography
-        component="p"
-        align="center"
-      >
-        { createAccount && createAccount }
-      </Typography>
+      <div className={classes.textCenter}>{createAccount}</div>
     </Grid>
   </Grid>
 );


### PR DESCRIPTION
This updates the CSS styles of the `Login` and `SignUp` components according to the new UI design.

**Login (mobile version)**
![Screenshot from 2020-01-24 12-14-15](https://user-images.githubusercontent.com/25912796/73088923-3a7bba80-3ea3-11ea-9242-3be3cb5cdc0f.png)

**SignIn (mobile version)**
![Screenshot from 2020-01-24 12-15-21](https://user-images.githubusercontent.com/25912796/73088986-5aab7980-3ea3-11ea-8503-efe81c588ca8.png)
