### PR TITLE
chore(package): Add script to use Talent's react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "start-storybook -p 8080",
     "build": "build-storybook -o public",
-    "dist": "rollup -c"
+    "dist": "rollup -c",
+    "link-talento-react": "rm -rf node_modules/react && ln -s ../../talento.laboratoria.la/node_modules/react ./node_modules/react"
   },
   "dependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
This adds a script that allows to use the `react` dependency of the **Talent app**, solving the [duplicate react](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) error when using [Hooks](https://reactjs.org/docs/hooks-intro.html).