### PR TITLE
Cambios en el link de Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Si deseas obtener más información sobre el proceso de desarrollo, el flujo de 
 
 ## Team
 
-Devs: Todo el equipo de [developers](https://github.com/orgs/Laboratoria/teams/developers) de Laboratoria
+Devs: Todo el equipo de [developers](https://github.com/orgs/Laboratoria/people) de Laboratoria
 
 ## Soporte
 


### PR DESCRIPTION
El Link anterior arrojaba un 404 en GitHub, supuse que se querían referir al equipo que tienen dentro de GitHub, asique modifique el valor por "https://github.com/orgs/Laboratoria/people" donde te muestran las personas que trabajan en la Organización.

En otro caso se podría modificar por https://developers.laboratoria.la/ donde se encuentra mas gente, en cualquiera de los dos casos quedo pendiente a su respuesta.

Saludos!